### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EmptyNN is implemented in R and depends on the **keras** and **Matrix** R packag
 
 ### Option 1
 ```
-$ git clone http://github.com/lkmklsmn/emptynn
+$ git clone http://github.com/lkmklsmn/empty_nn
 $ cd emptynn
 ## enter R and install packages
 $ R
@@ -28,7 +28,7 @@ $ R
 ```
 > install.packages("devtools")
 > library(devtools)
-> install_github("lkmklsmn/emptynn")
+> install_github("lkmklsmn/empty_nn")
 ```
 
 ## Usage

--- a/man/EmptyNN-package.Rd
+++ b/man/EmptyNN-package.Rd
@@ -23,9 +23,10 @@ Maintainer: \packageMaintainer{EmptyNN}
 \references{
 ~~ Literature or other references for background information ~~
 }
+
+\keyword{ package 
 ~~ Optionally other standard keywords, one per line, from file KEYWORDS in the R ~~
-~~ documentation directory ~~
-\keyword{ package }
+~~ documentation directory ~~}
 \seealso{
 ~~ Optional links to other man pages, e.g. ~~
 ~~ \code{\link[<pkg>:<pkg>-package]{<pkg>}} ~~


### PR DESCRIPTION
package name in readme is incorrect "empty_nn" and "EmptyNN-package.Rd" had text not in section preventing install_github from working. 